### PR TITLE
fixed docker web server / start.sh formatting problem

### DIFF
--- a/api/start.sh
+++ b/api/start.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+
+
 set -e
 
 ROLE=${CONTAINER_ROLE:-app}


### PR DESCRIPTION
i found that spacing was the problem that was only throwing error when you use windows powershell